### PR TITLE
fix: hook fails silently on `yarn add` during update of plugins

### DIFF
--- a/src/hooks/update.ts
+++ b/src/hooks/update.ts
@@ -4,5 +4,9 @@ import Plugins from '../plugins'
 
 export const update: Hook<'update'> = async function () {
   const plugins = new Plugins(this.config)
-  await plugins.update()
+  try {
+    await plugins.update()
+  } catch (e) {
+    this.error(e)
+  }
 }

--- a/src/hooks/update.ts
+++ b/src/hooks/update.ts
@@ -6,7 +6,7 @@ export const update: Hook<'update'> = async function () {
   const plugins = new Plugins(this.config)
   try {
     await plugins.update()
-  } catch (e) {
-    this.error(e)
+  } catch (error) {
+    this.error(error.message)
   }
 }


### PR DESCRIPTION
Fixes #76 