### PR TITLE
Support git+ssh and .git urls

### DIFF
--- a/src/commands/plugins/install.ts
+++ b/src/commands/plugins/install.ts
@@ -11,29 +11,34 @@ Can be installed from npm or a git url.
 Installation of a user-installed plugin will override a core plugin.
 
 e.g. If you have a core plugin that has a 'hello' command, installing a user-installed plugin with a 'hello' command will override the core plugin implementation. This is useful if a user needs to update core plugin functionality in the CLI without the need to patch and update the whole CLI.
-`
+`;
 
-  static usage = 'plugins:install PLUGIN...'
+  static usage = 'plugins:install PLUGIN...';
 
   static examples = [
     '$ <%= config.bin %> plugins:install <%- config.pjson.oclif.examplePlugin || "myplugin" %> ',
     '$ <%= config.bin %> plugins:install https://github.com/someuser/someplugin',
     '$ <%= config.bin %> plugins:install someuser/someplugin',
-  ]
+  ];
 
-  static strict = false
+  static strict = false;
 
-  static args = [{name: 'plugin', description: 'plugin to install', required: true}]
+  static args = [
+    {name: 'plugin', description: 'plugin to install', required: true},
+  ];
 
   static flags = {
     help: flags.help({char: 'h'}),
     verbose: flags.boolean({char: 'v'}),
-    force: flags.boolean({char: 'f', description: 'yarn install with force flag'}),
-  }
+    force: flags.boolean({
+      char: 'f',
+      description: 'yarn install with force flag',
+    }),
+  };
 
-  static aliases = ['plugins:add']
+  static aliases = ['plugins:add'];
 
-  plugins = new Plugins(this.config)
+  plugins = new Plugins(this.config);
 
   // In this case we want these operations to happen
   // sequentially so the `no-await-in-loop` rule is ugnored
@@ -51,8 +56,13 @@ e.g. If you have a core plugin that has a 'hello' command, installing a user-ins
         plugin: p,
       })
       if (p.type === 'npm') {
-        cli.action.start(`Installing plugin ${chalk.cyan(this.plugins.friendlyName(p.name))}`)
-        plugin = await this.plugins.install(p.name, {tag: p.tag, force: flags.force})
+        cli.action.start(
+          `Installing plugin ${chalk.cyan(this.plugins.friendlyName(p.name))}`,
+        )
+        plugin = await this.plugins.install(p.name, {
+          tag: p.tag,
+          force: flags.force,
+        })
       } else {
         cli.action.start(`Installing plugin ${chalk.cyan(p.url)}`)
         plugin = await this.plugins.install(p.url, {force: flags.force})
@@ -62,8 +72,12 @@ e.g. If you have a core plugin that has a 'hello' command, installing a user-ins
   }
   /* eslint-enable no-await-in-loop */
 
-  async parsePlugin(input: string): Promise<{name: string; tag: string; type: 'npm'} | {url: string; type: 'repo'}> {
-    if (input.startsWith('git+ssh://')) {
+  async parsePlugin(
+    input: string,
+  ): Promise<
+    { name: string; tag: string; type: 'npm' } | { url: string; type: 'repo' }
+  > {
+    if (input.startsWith('git+ssh://') || input.endsWith('.git')) {
       return {url: input, type: 'repo'}
     }
     if (input.includes('@') && input.includes('/')) {


### PR DESCRIPTION
We store private repositories in git, and require support for installing plugins via that route. This adds support for those url's.

This is an enhancement on top of #74.