### PR TITLE
fix: incorrect semver version for @oclif/color

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "author": "Jeff Dickey @jdxcode",
   "bugs": "https://github.com/oclif/plugin-plugins/issues",
   "dependencies": {
-    "@oclif/color": "^0.0.0",
+    "@oclif/color": "^0.x",
     "@oclif/command": "^1.5.12",
     "chalk": "^2.4.2",
     "cli-ux": "^5.2.1",


### PR DESCRIPTION
see #86 
`^0.0.0` will only match `0.0.0`, and will not pick up the latest `@oclif/color` which is at `0.1.0`, that fixes an exception.
`0.x` will properly match all pre-release versions.