### PR TITLE
fix: export the default plugins class

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,1 @@
-export * from './plugins'
+export {default} from './plugins'


### PR DESCRIPTION
Fixes https://github.com/oclif/plugin-plugins/issues/97

Recent updates to tslib no longer allow exporting * for defaults.