### PR TITLE
fix: allow tagged packages to be uninstalled

### DIFF
--- a/src/commands/plugins/uninstall.ts
+++ b/src/commands/plugins/uninstall.ts
@@ -36,9 +36,9 @@ export default class PluginsUninstall extends Command {
     if (flags.verbose) this.plugins.verbose = true
     if (argv.length === 0) argv.push('.')
     for (const plugin of argv) {
-      const friendly = this.plugins.friendlyName(plugin)
+      const friendly = this.removeTags(this.plugins.friendlyName(plugin))
       cli.action.start(`Uninstalling ${friendly}`)
-      const unfriendly = await this.plugins.hasPlugin(plugin)
+      const unfriendly = await this.plugins.hasPlugin(this.removeTags(plugin))
       if (!unfriendly) {
         const p = this.config.plugins.find(p => p.name === plugin) as Plugin | undefined
         if (p) {
@@ -51,4 +51,19 @@ export default class PluginsUninstall extends Command {
     }
   }
   /* eslint-enable no-await-in-loop */
+
+  private removeTags(plugin: string) {
+    if (plugin.includes('@')) {
+      const chunked = plugin.split('@')
+      const last = chunked[chunked.length - 1]
+
+      if (!last.includes('/') && chunked.length > 1) {
+        chunked.pop()
+      }
+
+      return chunked.join('@')
+    }
+
+    return plugin
+  }
 }

--- a/src/plugins.ts
+++ b/src/plugins.ts
@@ -181,13 +181,10 @@ export default class Plugins {
 
   async hasPlugin(name: string) {
     const list = await this.list()
-    return list.find(p => {
-      if (this.friendlyName(p.name) === this.friendlyName(name)) return true
-      if (p.type === 'link') {
-        if (path.resolve(p.root) === path.resolve(name)) return true
-      }
-      return false
-    })
+    const friendly = list.find(p => this.friendlyName(p.name) === this.friendlyName(name))
+    const unfriendly = list.find(p => this.unfriendlyName(p.name) === this.unfriendlyName(name))
+    const link = list.find(p => p.type === 'link' && path.resolve(p.root) === path.resolve(name))
+    return friendly ?? unfriendly ?? link ?? false
   }
 
   async yarnNodeVersion(): Promise<string | undefined> {

--- a/test/commands/plugins/index.test.ts
+++ b/test/commands/plugins/index.test.ts
@@ -16,6 +16,17 @@ describe('command', () => {
   .it('installs and uninstalls @oclif/example-plugin-ts')
 
   test
+  .command(['plugins:install', '@oclif/example-plugin-ts@latest'], {reset: true})
+  .stdout()
+  .command(['plugins'], {reset: true})
+  .do(output => expect(output.stdout).to.contain('@oclif/example-plugin-ts'))
+  .command(['plugins:uninstall', '@oclif/example-plugin-ts@latest'], {reset: true})
+  .stdout()
+  .command(['plugins'], {reset: true})
+  .do(output => expect(output.stdout).to.equal('no plugins installed\n'))
+  .it('installs and uninstalls @oclif/example-plugin-ts with tags')
+
+  test
   .command(['plugins:install', 'aliasme'], {reset: true})
   .stdout()
   .command(['plugins'], {reset: true})


### PR DESCRIPTION
Currently trying to uninstall a package using a tag name works for install but not uninstalling. The tag can be ignored and the uninstall should work with just the package name. This package has a oclif scope of `heroku-plugins` in the package.json which is why `./bin/run plugins:install apps` works in the tests.

## test
```
# friendly
./bin/run plugins:install apps
./bin/run plugins
./bin/run plugins:uninstall apps

# scoped
./bin/run plugins:install @heroku-cli/plugin-apps
./bin/run plugins
./bin/run plugins:uninstall @heroku-cli/plugin-apps

# tagged
./bin/run plugins:install @heroku-cli/plugin-apps@latest
./bin/run plugins
./bin/run plugins:uninstall @heroku-cli/plugin-apps@latest

# unscoped
./bin/run plugins:install salesforce-alm
./bin/run plugins
./bin/run plugins:uninstall salesforce-alm
```

## result
```
Installing plugin apps... installed v7.47.0
apps 7.47.0
Uninstalling apps... done
Installing plugin apps... installed v7.47.0
apps 7.47.0
Uninstalling apps... done
Installing plugin apps... installed v7.47.0
apps 7.47.0
Uninstalling apps... done
warning salesforce-alm > request-promise-native@1.0.9: request-promise-native has been deprecated because it extends the now deprecated request package, see https://github.com/request/request/issues/3142
warning salesforce-alm > request@2.88.2: request has been deprecated, see https://github.com/request/request/issues/3142
warning salesforce-alm > jsforce > request@2.88.2: request has been deprecated, see https://github.com/request/request/issues/3142
warning salesforce-alm > @salesforce/core > jsforce > request@2.88.2: request has been deprecated, see https://github.com/request/request/issues/3142
warning salesforce-alm > request > har-validator@5.1.5: this library is no longer supported
Installing plugin salesforce-alm... installed v50.6.0
salesforce-alm 50.6.0
Uninstalling salesforce-alm... done
```