### PR TITLE
fix: remove TS compile step for linked plugins

### DIFF
--- a/src/plugins.ts
+++ b/src/plugins.ts
@@ -154,14 +154,6 @@ export default class Plugins {
     // refresh will cause yarn.lock to install dependencies, including devDeps
     await this.refresh(c.root, {prod: false})
     await this.add({type: 'link', name: c.name, root: c.root})
-    // if the plugin has typescript in devDeps, we will also compile it
-    if (c.pjson.devDependencies?.typescript) {
-      try {
-        await this.yarn.exec(['run', 'tsc', '-p', '.', '--incremental', '--skipLibCheck'], {cwd: path.resolve(p), verbose: this.verbose})
-      } catch {
-        this.debug('typescript compilation failed')
-      }
-    }
   }
 
   async add(plugin: Interfaces.PJSON.PluginTypes): Promise<void> {


### PR DESCRIPTION
Reverts https://github.com/oclif/plugin-plugins/pull/517

`oclif/core` now uses `ts-node` to compile linked TS plugins at runtime so this compile step in `plugins link` is no longer needed.
https://github.com/oclif/core/pull/650
[@W-12702335@](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00001NKv6SYAT/view)