### PR TITLE
fix: handle legacy plugins

### DIFF
--- a/.github/workflows/onPushToMain.yml
+++ b/.github/workflows/onPushToMain.yml
@@ -3,7 +3,9 @@ name: version, tag and github release
 
 on:
   push:
-    branches: [main]
+    branches: 
+      - main 
+      - prerelease/*
 
 jobs:
   release:

--- a/.github/workflows/onRelease.yml
+++ b/.github/workflows/onRelease.yml
@@ -11,9 +11,20 @@ on:
         type: string
         required: true
 jobs:
+  getDistTag:
+    outputs:
+      tag: ${{ steps.distTag.outputs.tag }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.release.tag_name || inputs.tag  }}
+      - uses: oclif/github-workflows/.github/actions/getPreReleaseTag@main
+        id: distTag
   npm:
     uses: oclif/github-workflows/.github/workflows/npmPublish.yml@main
+    needs: [getDistTag]
     with:
-      tag: latest
+      tag: ${{ needs.getDistTag.outputs.tag || 'latest' }}
       githubTag: ${{ github.event.release.tag_name || inputs.tag }}
     secrets: inherit

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## [2.4.4-beta.1](https://github.com/oclif/plugin-plugins/compare/2.4.3...2.4.4-beta.1) (2023-04-03)
+
+
+### Bug Fixes
+
+* handle legacy plugins ([4ccb2fb](https://github.com/oclif/plugin-plugins/commit/4ccb2fb8ce6d8e04fa11ca414da4000af8a09827))
+
+
+
 ## [2.4.3](https://github.com/oclif/plugin-plugins/compare/2.4.2...2.4.3) (2023-03-18)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## [2.4.4-beta.3](https://github.com/oclif/plugin-plugins/compare/2.4.4-beta.1...2.4.4-beta.3) (2023-04-03)
+
+
+### Bug Fixes
+
+* bump version ([2881cfe](https://github.com/oclif/plugin-plugins/commit/2881cfeba8f0b295277e89e02c04dfa99d2113df))
+
+
+
 ## [2.4.4-beta.1](https://github.com/oclif/plugin-plugins/compare/2.4.3...2.4.4-beta.1) (2023-04-03)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## [2.4.4-beta.4](https://github.com/oclif/plugin-plugins/compare/2.4.4-beta.3...2.4.4-beta.4) (2023-04-03)
+
+
+### Bug Fixes
+
+* check class instance ([55ac4dc](https://github.com/oclif/plugin-plugins/commit/55ac4dce3dc71dfd988e46eb7d31dd7702334ee0))
+* just check base prop ([1b4868f](https://github.com/oclif/plugin-plugins/commit/1b4868f740dbc0136e64157d0f37717d21e86d73))
+
+
+
 ## [2.4.4-beta.3](https://github.com/oclif/plugin-plugins/compare/2.4.4-beta.1...2.4.4-beta.3) (2023-04-03)
 
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@oclif/plugin-plugins",
   "description": "plugins plugin for oclif",
-  "version": "2.4.4-beta.2",
+  "version": "2.4.4-beta.3",
   "author": "Salesforce",
   "bugs": "https://github.com/oclif/plugin-plugins/issues",
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@oclif/plugin-plugins",
   "description": "plugins plugin for oclif",
-  "version": "2.4.3",
+  "version": "2.4.4-beta.0",
   "author": "Salesforce",
   "bugs": "https://github.com/oclif/plugin-plugins/issues",
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@oclif/plugin-plugins",
   "description": "plugins plugin for oclif",
-  "version": "2.4.4-beta.3",
+  "version": "2.4.4-beta.4",
   "author": "Salesforce",
   "bugs": "https://github.com/oclif/plugin-plugins/issues",
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@oclif/plugin-plugins",
   "description": "plugins plugin for oclif",
-  "version": "2.4.4-beta.0",
+  "version": "2.4.4-beta.1",
   "author": "Salesforce",
   "bugs": "https://github.com/oclif/plugin-plugins/issues",
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@oclif/plugin-plugins",
   "description": "plugins plugin for oclif",
-  "version": "2.4.4-beta.1",
+  "version": "2.4.4-beta.2",
   "author": "Salesforce",
   "bugs": "https://github.com/oclif/plugin-plugins/issues",
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@oclif/plugin-plugins",
   "description": "plugins plugin for oclif",
-  "version": "2.4.4-beta.4",
+  "version": "2.4.3",
   "author": "Salesforce",
   "bugs": "https://github.com/oclif/plugin-plugins/issues",
   "dependencies": {

--- a/src/plugins.ts
+++ b/src/plugins.ts
@@ -352,10 +352,9 @@ export default class Plugins {
   private isValidPlugin(p: Config): boolean {
     if (p.valid) return true
 
-    if (!this.config.plugins.find(p => p.name === '@oclif/plugin-legacy') &&
-      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-      // @ts-ignore check if this plugin was loaded by `plugin-legacy`
-      p._base.includes('@oclif/plugin-legacy')
+    // check if this plugin was loaded by `plugin-legacy`
+    if (!this.config.plugins.find(p => p.name === '@oclif/plugin-legacy') ||
+        Object.getPrototypeOf(p) === 'PluginLegacy'
     ) {
       return true
     }

--- a/src/plugins.ts
+++ b/src/plugins.ts
@@ -350,20 +350,20 @@ export default class Plugins {
   }
 
   private isValidPlugin(p: Config): boolean {
-    if (
-      !p.valid &&
-      !this.config.plugins.find(p => p.name === '@oclif/plugin-legacy') &&
+    if (p.valid) return true
+
+    if (!this.config.plugins.find(p => p.name === '@oclif/plugin-legacy') &&
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
       // @ts-ignore check if this plugin was loaded by `plugin-legacy`
-      p._base.contains('@oclif/plugin-legacy')
-      ) {
-        return true
-      }
-    {
-      throw new Errors.CLIError('plugin is invalid', {
+      p._base.includes('@oclif/plugin-legacy')
+    ) {
+      return true
+    }
+
+    throw new Errors.CLIError('plugin is invalid', {
       suggestions: [
         'Plugin failed to install because it does not appear to be a valid CLI plugin.\nIf you are sure it is, contact the CLI developer noting this error.',
       ],
     })
-    }
   }
 }

--- a/src/plugins.ts
+++ b/src/plugins.ts
@@ -58,11 +58,6 @@ export default class Plugins {
       await this.createPJSON()
       let plugin
       const add = force ? ['add', '--force'] : ['add']
-      const invalidPluginError = new Errors.CLIError('plugin is invalid', {
-        suggestions: [
-          'Plugin failed to install because it does not appear to be a valid CLI plugin.\nIf you are sure it is, contact the CLI developer noting this error.',
-        ],
-      })
       if (name.includes(':')) {
         // url
         const url = name
@@ -77,12 +72,8 @@ export default class Plugins {
           name,
         })
         await this.refresh(plugin.root)
-        if (
-          !plugin.valid &&
-          !this.config.plugins.find(p => p.name === '@oclif/plugin-legacy')
-        ) {
-          throw invalidPluginError
-        }
+
+        this.isValidPlugin(plugin)
 
         await this.add({name, url, type: 'user'})
       } else {
@@ -100,12 +91,8 @@ export default class Plugins {
           root: path.join(this.config.dataDir, 'node_modules', name),
           name,
         })
-        if (
-          !plugin.valid &&
-          !this.config.plugins.find(p => p.name === '@oclif/plugin-legacy')
-        ) {
-          throw invalidPluginError
-        }
+
+        this.isValidPlugin(plugin)
 
         await this.refresh(plugin.root)
         await this.add({name, tag: range || tag, type: 'user'})
@@ -144,12 +131,7 @@ export default class Plugins {
   async link(p: string): Promise<void> {
     const c = await Config.load(path.resolve(p))
     ux.action.start(`${this.config.name}: linking plugin ${c.name}`)
-    if (
-      !c.valid &&
-      !this.config.plugins.find(p => p.name === '@oclif/plugin-legacy')
-    ) {
-      throw new Errors.CLIError('plugin is not a valid oclif plugin')
-    }
+    this.isValidPlugin(c)
 
     // refresh will cause yarn.lock to install dependencies, including devDeps
     await this.refresh(c.root, {prod: false})
@@ -365,5 +347,23 @@ export default class Plugins {
         (a.type === 'link' && b.type === 'link' && a.root === b.root),
     )
     return plugins
+  }
+
+  private isValidPlugin(p: Config): boolean {
+    if (
+      !p.valid &&
+      !this.config.plugins.find(p => p.name === '@oclif/plugin-legacy') &&
+      // @ts-ignore check if this plugin was loaded by `plugin-legacy`
+      p._base.contains('@oclif/plugin-legacy')
+      ) {
+        return true
+      }
+    {
+      throw new Errors.CLIError('plugin is invalid', {
+      suggestions: [
+        'Plugin failed to install because it does not appear to be a valid CLI plugin.\nIf you are sure it is, contact the CLI developer noting this error.',
+      ],
+    })
+    }
   }
 }

--- a/src/plugins.ts
+++ b/src/plugins.ts
@@ -352,9 +352,10 @@ export default class Plugins {
   private isValidPlugin(p: Config): boolean {
     if (p.valid) return true
 
-    // check if this plugin was loaded by `plugin-legacy`
     if (!this.config.plugins.find(p => p.name === '@oclif/plugin-legacy') ||
-        Object.getPrototypeOf(p) === 'PluginLegacy'
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore check if this plugin was loaded by `plugin-legacy`
+      p._base.includes('@oclif/plugin-legacy')
     ) {
       return true
     }


### PR DESCRIPTION
Fix `plugins:install` failing to install legacy (`cli-engine`, old heroku) plugins.

After moving to latest `oclif/core` and `plugin-plugins`, the heroku CLI started to fail when trying to install legacy plugins, probably caused by this code:
https://github.com/oclif/core/blob/a18803454449986e03549838ba3928c66f98da37/src/config/plugin.ts#L161-L165

`heroku` has `plugin-legacy` as a dependency to make legacy plugins work with latest oclif/core:
https://github.com/heroku/cli/blob/master/packages/cli/package.json#L39

init hook that does the plugin conversion at runtime:
https://github.com/oclif/plugin-legacy/blob/main/src/hooks/init.ts

This PR fixes the issue by checking if the plugin being installed was loaded by `plugin-legacy` as an instance of `PluginLegacy`.