### PR TITLE
chore: remove unused deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,12 +5,10 @@
   "author": "Salesforce",
   "bugs": "https://github.com/oclif/plugin-plugins/issues",
   "dependencies": {
-    "@oclif/color": "^1.0.4",
     "@oclif/core": "^2.8.2",
     "chalk": "^4.1.2",
     "debug": "^4.3.4",
     "fs-extra": "^9.0",
-    "http-call": "^5.2.2",
     "load-json-file": "^5.3.0",
     "npm": "^9.6.5",
     "npm-run-path": "^4.0.1",

--- a/src/commands/plugins/index.ts
+++ b/src/commands/plugins/index.ts
@@ -1,4 +1,4 @@
-import color from '@oclif/color'
+import * as chalk from 'chalk'
 import {Command, Flags, Plugin, ux} from '@oclif/core'
 
 import Plugins from '../../plugins'
@@ -52,13 +52,13 @@ export default class PluginsIndex extends Command {
   }
 
   private formatPlugin(plugin: any): string {
-    let output = `${this.plugins.friendlyName(plugin.name)} ${color.dim(plugin.version)}`
+    let output = `${this.plugins.friendlyName(plugin.name)} ${chalk.dim(plugin.version)}`
     if (plugin.type !== 'user')
-      output += color.dim(` (${plugin.type})`)
+      output += chalk.dim(` (${plugin.type})`)
     if (plugin.type === 'link')
       output += ` ${plugin.root}`
     else if (plugin.tag && plugin.tag !== 'latest')
-      output += color.dim(` (${String(plugin.tag)})`)
+      output += chalk.dim(` (${String(plugin.tag)})`)
     return output
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -740,7 +740,7 @@
     read-package-json-fast "^3.0.0"
     which "^3.0.0"
 
-"@oclif/color@^1.0.3", "@oclif/color@^1.0.4":
+"@oclif/color@^1.0.3":
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/@oclif/color/-/color-1.0.4.tgz#07e54e3bd76a29e77d6ad71aef33222fe4f728e7"
   integrity sha512-HEcVnSzpQkjskqWJyVN3tGgR0H0F8GrBmDjgQ1N0ZwwktYa4y9kfV07P/5vt5BjPXNyslXHc4KAO8Bt7gmErCA==


### PR DESCRIPTION
Remove `http-call` (last ref I found was this: https://github.com/oclif/plugin-plugins/pull/283/files) and replaces `oclif/color` with `chalk`.

@W-0@