### PR TITLE
fix: validate plugin name before install

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@oclif/plugin-plugins",
   "description": "plugins plugin for oclif",
-  "version": "2.4.8",
+  "version": "3.0.0",
   "author": "Salesforce",
   "bugs": "https://github.com/oclif/plugin-plugins/issues",
   "dependencies": {
@@ -48,7 +48,7 @@
     "typescript": "4.9.5"
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=16"
   },
   "files": [
     "oclif.manifest.json",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "semver": "^7.5.0",
     "shelljs": "^0.8.5",
     "tslib": "^2.4.1",
+    "validate-npm-package-name": "^5.0.0",
     "yarn": "^1.22.18"
   },
   "devDependencies": {
@@ -30,6 +31,7 @@
     "@types/semver": "^7.3.13",
     "@types/shelljs": "^0.8.12",
     "@types/supports-color": "^7.2.0",
+    "@types/validate-npm-package-name": "^4.0.0",
     "chai": "^4.3.7",
     "commitlint": "^12.1.4",
     "eslint": "^7.31.0",

--- a/src/commands/plugins/install.ts
+++ b/src/commands/plugins/install.ts
@@ -1,5 +1,6 @@
-import {Command, Flags, ux, Args} from '@oclif/core'
+import {Command, Flags, ux, Args, Errors} from '@oclif/core'
 import * as chalk from 'chalk'
+import * as validateNpmPkgName from 'validate-npm-package-name'
 
 import Plugins from '../../plugins'
 
@@ -49,6 +50,12 @@ e.g. If you have a core plugin that has a 'hello' command, installing a user-ins
     for (let name of argv as string[]) {
       if (aliases[name] === null) this.error(`${name} is blocked`)
       name = aliases[name] || name
+
+      const res = validateNpmPkgName(name)
+      if (!res.validForNewPackages) {
+        throw new Errors.CLIError('Invalid npm package name')
+      }
+
       const p = await this.parsePlugin(name)
       let plugin
       await this.config.runHook('plugins:preinstall', {

--- a/src/commands/plugins/install.ts
+++ b/src/commands/plugins/install.ts
@@ -1,6 +1,6 @@
 import {Command, Flags, ux, Args, Errors} from '@oclif/core'
+import * as validate from 'validate-npm-package-name'
 import * as chalk from 'chalk'
-import * as validateNpmPkgName from 'validate-npm-package-name'
 
 import Plugins from '../../plugins'
 
@@ -50,12 +50,6 @@ e.g. If you have a core plugin that has a 'hello' command, installing a user-ins
     for (let name of argv as string[]) {
       if (aliases[name] === null) this.error(`${name} is blocked`)
       name = aliases[name] || name
-
-      const res = validateNpmPkgName(name)
-      if (!res.validForNewPackages) {
-        throw new Errors.CLIError('Invalid npm package name')
-      }
-
       const p = await this.parsePlugin(name)
       let plugin
       await this.config.runHook('plugins:preinstall', {
@@ -92,6 +86,7 @@ e.g. If you have a core plugin that has a 'hello' command, installing a user-ins
     if (input.includes('@') && input.includes('/')) {
       input = input.slice(1)
       const [name, tag = 'latest'] = input.split('@')
+      validateNpmPkgName('@' + name)
       return {name: '@' + name, tag, type: 'npm'}
     }
 
@@ -102,6 +97,13 @@ e.g. If you have a core plugin that has a 'hello' command, installing a user-ins
 
     const [splitName, tag = 'latest'] = input.split('@')
     const name = await this.plugins.maybeUnfriendlyName(splitName)
+    validateNpmPkgName(name)
     return {name, tag, type: 'npm'}
+  }
+}
+
+function validateNpmPkgName(name:string): void {
+  if (!validate(name).validForNewPackages) {
+    throw new Errors.CLIError('Invalid npm package name.')
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1163,6 +1163,11 @@
   resolved "https://registry.yarnpkg.com/@types/supports-color/-/supports-color-7.2.0.tgz#edd98ae52ee786b733a5dea0a23da4eb18ef7310"
   integrity sha512-gtUcOP6qIpjbSDdWjMBRNSks42ccx1709mwKTgelW63BESIADw8Ju7klpydDDb9Kr0iRXfpwrXH8+zoU8TCqiA==
 
+"@types/validate-npm-package-name@^4.0.0":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/@types/validate-npm-package-name/-/validate-npm-package-name-4.0.0.tgz#3b53194dd3888fbb01f794fa368fb3472381d1fe"
+  integrity sha512-RpO62vB2lkjEkyLbwTheA2+uwYmtVMWTr/kWRI++UAgVdZqNqdAuIQl/SxBCGeMKfdjWaXPbyhZbiCc4PAj+KA==
+
 "@types/vinyl@^2.0.4":
   version "2.0.6"
   resolved "https://registry.npmjs.org/@types/vinyl/-/vinyl-2.0.6.tgz#b2d134603557a7c3d2b5d3dc23863ea2b5eb29b0"


### PR DESCRIPTION
Fixes: https://github.com/oclif/plugin-plugins/issues/594

Use `validate-npm-package-name` to validate the plugin name is a valid npm pkg name before doing any initialization.
https://github.com/npm/validate-npm-package-name

@W-13099057@