### PR TITLE
feat: use spawn instead of fork

### DIFF
--- a/src/yarn.ts
+++ b/src/yarn.ts
@@ -1,4 +1,5 @@
 import {Interfaces, ux} from '@oclif/core'
+import {fork, spawn} from 'child_process'
 import NpmRunPath from 'npm-run-path'
 import * as path from 'path'
 
@@ -17,11 +18,10 @@ export default class Yarn {
 
   fork(modulePath: string, args: string[] = [], options: any = {}): Promise<void> {
     return new Promise((resolve, reject) => {
-      const {fork} = require('child_process')
       const forked = fork(modulePath, args, options)
-      forked.stderr.on('data', (d: any) => process.stderr.write(d))
-      forked.stdout.setEncoding('utf8')
-      forked.stdout.on('data', (d: any) => {
+      forked.stderr?.on('data', (d: any) => process.stderr.write(d))
+      forked.stdout?.setEncoding('utf8')
+      forked.stdout?.on('data', (d: any) => {
         if (options.verbose) process.stdout.write(d)
         else ux.action.status = d.replace(/\n$/, '').split('\n').pop()
       })
@@ -31,7 +31,33 @@ export default class Yarn {
         if (code === 0) {
           resolve()
         } else {
-          reject(new Error(`yarn ${args.join(' ')} exited with code ${code}`))
+          reject(new Error(`${modulePath} ${args.join(' ')} exited with code ${code}`))
+        }
+      })
+
+      // Fix windows bug with node-gyp hanging for input forever
+      // if (this.config.windows) {
+      //   forked.stdin.write('\n')
+      // }
+    })
+  }
+
+  spawn(executable: string, args: string[] = [], options: any = {}): Promise<void> {
+    return new Promise((resolve, reject) => {
+      const spawned = spawn(executable, args, options)
+      spawned.stderr.on('data', (d: any) => process.stderr.write(d))
+      spawned.stdout.setEncoding('utf8')
+      spawned.stdout.on('data', (d: any) => {
+        if (options.verbose) process.stdout.write(d)
+        else ux.action.status = d.replace(/\n$/, '').split('\n').pop()
+      })
+
+      spawned.on('error', reject)
+      spawned.on('exit', (code: number) => {
+        if (code === 0) {
+          resolve()
+        } else {
+          reject(new Error(`${executable} ${args.join(' ')} exited with code ${code}`))
         }
       })
 
@@ -77,7 +103,11 @@ export default class Yarn {
 
     debug(`${cwd}: ${this.bin} ${args.join(' ')}`)
     try {
-      await this.fork(this.bin, args, options)
+      // TODO: always use spawn instead of fork once this has been thoroughly tested
+      this.config.scopedEnvVarTrue('PLUGINS_INSTALL_USE_SPAWN') ?
+        await this.spawn(this.bin, args, options) :
+        await this.fork(this.bin, args, options)
+
       debug('done')
     } catch (error: any) {
       // to-do: https://github.com/yarnpkg/yarn/issues/2191


### PR DESCRIPTION
`child_process.fork` creates a copy of the running process, which is proving to be problematic when running node with `--loader ts-node/esm`. Switching to `spawn` resolves the issue since it will create an entirely new process for the command to run

For the time being I'm putting this behind a scoped env var, `PLUGINS_INSTALL_USE_SPAWN`. So the default behavior will remain the same. We'll switch the default to `spawn` once it has been fully tested 