### PR TITLE
Add npm update workflow

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,5 +18,6 @@ updates:
       prefix-development: chore(dev-deps)
     ignore:
       - dependency-name: '@salesforce/dev-scripts'
+      - dependency-name: 'npm' # Updated with update-npm-version.yml
       - dependency-name: '*'
         update-types: ['version-update:semver-major']

--- a/.github/workflows/failureNotifications.yml
+++ b/.github/workflows/failureNotifications.yml
@@ -5,6 +5,7 @@ on:
     workflows:
       - version, tag and github release
       - publish
+      - update-npm-version
     types:
       - completed
 

--- a/.github/workflows/update-npm-version.yml
+++ b/.github/workflows/update-npm-version.yml
@@ -24,6 +24,7 @@ jobs:
       # Push changes if 'git status' is not empty
       - run: |
           if [[ -n $(git status --short) ]]; then
+            yarn test
             git add -A
             git commit -m "fix: update npm version"
             git push

--- a/.github/workflows/update-npm-version.yml
+++ b/.github/workflows/update-npm-version.yml
@@ -1,0 +1,32 @@
+name: update-npm-version
+
+# https://github.com/forcedotcom/cli/issues/2327
+# Customer needs an npm version that has been bundled with node lts
+# We will install the version that is included with the runner's node
+
+on:
+  workflow_dispatch:
+  schedule:
+    # Tuesday 7a central (12 UTC)
+    - cron: '0 12 * * 2'
+
+jobs:
+  update-node:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: lts/*
+      - uses: salesforcecli/github-workflows/.github/actions/yarnInstallWithRetries@main
+      - run: yarn add npm@$(npm -v)
+      - uses: salesforcecli/github-workflows/.github/actions/gitConfig@main
+      # Push changes if 'git status' is not empty
+      - run: |
+          if [[ -n $(git status --short) ]]; then
+            git add -A
+            git commit -m "fix: update npm version"
+            git push
+          else
+            echo "Already up to date"
+          fi


### PR DESCRIPTION
We have a customer needs the included `npm` version to be one that has (at some point) been bundled with node lts.
We will install the `npm` version that is included with the Github Action runner's LTS node

If there are changes, we will commit them to `main`. This will run weekly on Tuesdays, that way it will be included in Tuesday's `nightly` to be promoted to `latest-rc` on Wednesday

[@W-13848117@](https://gus.my.salesforce.com/apex/ADM_WorkLocator?bugorworknumber=W-13848117)
Issue: https://github.com/forcedotcom/cli/issues/2327
Related: https://github.com/salesforcecli/plugin-trust/pull/572