### PR TITLE
feat: check for renamed yarn.lock during install

### DIFF
--- a/src/plugins.ts
+++ b/src/plugins.ts
@@ -141,15 +141,16 @@ export default class Plugins {
       })
     }
 
-    if (await fileExists(path.join(root, 'deps.lock'))) {
-      this.debug(`deps.lock exists at ${root}. Installing prod dependencies`)
-      await fs.promises.rename(path.join(root, 'deps.lock'), path.join(root, 'yarn.lock'))
+    if (await fileExists(path.join(root, 'oclif.lock'))) {
+      this.debug(`oclif.lock exists at ${root}. Installing prod dependencies`)
+      await fs.promises.rename(path.join(root, 'oclif.lock'), path.join(root, 'yarn.lock'))
       await doRefresh()
+      await fs.promises.unlink(path.join(root, 'yarn.lock'))
     } else if (await fileExists(path.join(root, 'yarn.lock'))) {
       this.debug(`yarn.lock exists at ${root}. Installing prod dependencies`)
       await doRefresh()
     } else {
-      this.debug(`no yarn.lock or deps.lock exists at ${root}. Skipping dependency refresh`)
+      this.debug(`no yarn.lock or oclif.lock exists at ${root}. Skipping dependency refresh`)
     }
   }
 

--- a/src/yarn.ts
+++ b/src/yarn.ts
@@ -1,5 +1,5 @@
 import {Interfaces, ux} from '@oclif/core'
-import {fork, spawn} from 'child_process'
+import {fork} from 'child_process'
 import NpmRunPath from 'npm-run-path'
 import * as path from 'path'
 
@@ -32,37 +32,6 @@ export default class Yarn {
           resolve()
         } else {
           reject(new Error(`${modulePath} ${args.join(' ')} exited with code ${code}`))
-        }
-      })
-
-      // Fix windows bug with node-gyp hanging for input forever
-      // if (this.config.windows) {
-      //   forked.stdin.write('\n')
-      // }
-    })
-  }
-
-  spawn(executable: string, args: string[] = [], options: any = {}): Promise<void> {
-    return new Promise((resolve, reject) => {
-      const spawned = spawn(executable, args, {...options, shell: true})
-      spawned.stderr.setEncoding('utf8')
-      spawned.stderr.on('data', (d: any) => {
-        debug('spawned yarn stderr:', d)
-        process.stderr.write(d)
-      })
-      spawned.stdout.setEncoding('utf8')
-      spawned.stdout.on('data', (d: any) => {
-        debug('spawned yarn stdout:', d)
-        if (options.verbose) process.stdout.write(d)
-        else ux.action.status = d.replace(/\n$/, '').split('\n').pop()
-      })
-
-      spawned.on('error', reject)
-      spawned.on('exit', (code: number) => {
-        if (code === 0) {
-          resolve()
-        } else {
-          reject(new Error(`${executable} ${args.join(' ')} exited with code ${code}`))
         }
       })
 
@@ -111,11 +80,7 @@ export default class Yarn {
 
     debug(`${cwd}: ${this.bin} ${args.join(' ')}`)
     try {
-      // TODO: always use spawn instead of fork once this has been thoroughly tested
-      this.config.scopedEnvVarTrue('PLUGINS_INSTALL_USE_SPAWN') ?
-        await this.spawn(this.bin, args, options) :
-        await this.fork(this.bin, args, options)
-
+      await this.fork(this.bin, args, options)
       debug('yarn done')
     } catch (error: any) {
       debug('yarn error', error)


### PR DESCRIPTION
- Checks for `oclif.lock` to see if `yarn` should be rerun with the `--prod` flag
- Removes experimental feature introduced here: https://github.com/oclif/plugin-plugins/pull/638

@W-14010705@