### PR TITLE
feat: incorporate jit plugins

### DIFF
--- a/src/commands/plugins/index.ts
+++ b/src/commands/plugins/index.ts
@@ -1,8 +1,11 @@
 import * as chalk from 'chalk'
-import {Command, Flags, Plugin, ux} from '@oclif/core'
+import {Command, Flags, Interfaces, Plugin, ux} from '@oclif/core'
 
 import Plugins from '../../plugins'
 import {sortBy} from '../../util'
+
+type JitPlugin =  {name: string; version: string; type: 'jit'}
+type PluginsJson = Array<Interfaces.Plugin | JitPlugin>
 
 export default class PluginsIndex extends Command {
   static enableJsonFlag = true
@@ -16,7 +19,7 @@ export default class PluginsIndex extends Command {
 
   plugins = new Plugins(this.config)
 
-  async run(): Promise<ReturnType<Plugins['list']>> {
+  async run(): Promise<PluginsJson> {
     const {flags} = await this.parse(PluginsIndex)
     let plugins = this.config.getPluginsList()
     sortBy(plugins, p => this.plugins.friendlyName(p.name))
@@ -29,11 +32,19 @@ export default class PluginsIndex extends Command {
       return []
     }
 
+    const jitPluginsConfig = this.config.pjson.oclif.jitPlugins ?? {}
+
+    const jitPlugins: JitPlugin[] = Object.entries(jitPluginsConfig).map(([name, version]) => ({name: this.plugins.friendlyName(name), version, type: 'jit'}))
+    sortBy(jitPlugins, p => p.name)
+
     if (!this.jsonEnabled()) {
       this.display(plugins as Plugin[])
+      this.displayJitPlugins(jitPlugins)
     }
 
-    return this.plugins.list()
+    const results = this.config.getPluginsList()
+
+    return [...results, ...jitPlugins]
   }
 
   private display(plugins: Plugin[]) {
@@ -43,6 +54,14 @@ export default class PluginsIndex extends Command {
         const tree = this.createTree(plugin)
         tree.display()
       }
+    }
+  }
+
+  private displayJitPlugins(jitPlugins: JitPlugin[]) {
+    if (jitPlugins.length === 0) return
+    this.log(chalk.dim('\nUninstalled JIT Plugins:'))
+    for (const {name, version} of jitPlugins) {
+      this.log(`${name} ${chalk.dim(version)}`)
     }
   }
 

--- a/src/commands/plugins/inspect.ts
+++ b/src/commands/plugins/inspect.ts
@@ -90,6 +90,10 @@ export default class PluginsInspect extends Command {
     const pluginConfig = this.config.getPluginsList().find(plg => plg.name === pluginName)
 
     if (pluginConfig) return pluginConfig as Plugin
+    if (this.config.pjson.oclif.jitPlugins?.[pluginName]) {
+      this.warn(`Plugin ${pluginName} is a JIT plugin. It will be installed the first time you run one of it's commands.`)
+    }
+
     throw new Error(`${pluginName} not installed`)
   }
 

--- a/src/commands/plugins/install.ts
+++ b/src/commands/plugins/install.ts
@@ -106,11 +106,13 @@ e.g. If you have a core plugin that has a 'hello' command, installing a user-ins
 
     if (this.flags.jit) {
       const jitVersion = this.config.pjson.oclif?.jitPlugins?.[name]
-      if (jitVersion && input.includes('@')) {
-        this.warn(`--jit flag is present. Ignoring tag ${tag} and using the version specified in package.json (${jitVersion}).`)
+      if (jitVersion) {
+        if (input.includes('@')) this.warn(`--jit flag is present along side a tag. Ignoring tag ${tag} and using the version specified in package.json (${jitVersion}).`)
+        return {name, tag: jitVersion ?? tag, type: 'npm'}
       }
 
-      return {name, tag: jitVersion ?? tag, type: 'npm'}
+      this.warn(`--jit flag is present but ${name} is not a JIT plugin. Installing ${tag} instead.`)
+      return {name, tag, type: 'npm'}
     }
 
     return {name, tag, type: 'npm'}

--- a/src/commands/plugins/install.ts
+++ b/src/commands/plugins/install.ts
@@ -131,7 +131,7 @@ e.g. If you have a core plugin that has a 'hello' command, installing a user-ins
       const jitVersion = this.config.pjson.oclif?.jitPlugins?.[name]
       if (jitVersion) {
         if (input.includes('@')) this.warn(`--jit flag is present along side a tag. Ignoring tag ${tag} and using the version specified in package.json (${jitVersion}).`)
-        return {name, tag: jitVersion ?? tag, type: 'npm'}
+        return {name, tag: jitVersion, type: 'npm'}
       }
 
       this.warn(`--jit flag is present but ${name} is not a JIT plugin. Installing ${tag} instead.`)

--- a/test/commands/plugins/index.test.ts
+++ b/test/commands/plugins/index.test.ts
@@ -20,15 +20,18 @@ describe('command', () => {
   .it('installs and uninstalls @oclif/example-plugin-ts')
 
   test
+  .stdout()
   .command(['plugins', '--json'], {reset: true})
   .do(output => expect((output.returned)).to.deep.equal([]))
   .command(['plugins:install', '@oclif/example-plugin-ts'], {reset: true})
+  .stdout()
   .command(['plugins', '--json'], {reset: true})
   .do(output => expect((output.returned as [{name: string}]).find(o => o.name === '@oclif/example-plugin-ts')).to.have.property('type', 'user'))
   .stdout()
   .command(['hello'], {reset: true})
   .do(output => expect(output.stdout).to.contain('hello world'))
   .command(['plugins:uninstall', '@heroku-cli/plugin-@oclif/example-plugin-ts'])
+  .stdout()
   .command(['plugins', '--json'], {reset: true})
   .do(output => expect((output.returned)).to.deep.equal([]))
   .it('installs and uninstalls @oclif/example-plugin-ts (--json)')


### PR DESCRIPTION
- Adds hidden `--jit` flag to `plugins install` for installing JIT plugin with the version specified by root plugin
- Adds warning message when running `plugins inspect` on an uninstalled JIT plugin
- Updates `--json` output for `plugins` to include all plugins (previously it was just user installed and linked plugins). This is not a breaking change since all the properties on the old json are still available on the new
- Adds list of uninstalled JIT plugins to `plugins --core` human readable output
![Screenshot 2023-09-14 at 3 03 04 PM](https://github.com/oclif/plugin-plugins/assets/10244328/cdc52569-0841-4c11-a1f7-7e6fe50d4371)
