### PR TITLE
Yarn network mutex

### DIFF
--- a/src/yarn.ts
+++ b/src/yarn.ts
@@ -46,11 +46,17 @@ export default class Yarn {
   async exec(args: string[] = [], opts: {cwd: string; verbose: boolean}): Promise<void> {
     const cwd = opts.cwd
     if (args[0] !== 'run') {
+      // https://classic.yarnpkg.com/lang/en/docs/cli/#toc-concurrency-and-mutex
+      // Default port is: 31997
+      const port = this.config.scopedEnvVar('NETWORK_MUTEX_PORT')
+      const optionalPort = port ? `:${port}` : ''
+      const mutex = this.config.scopedEnvVar('USE_NETWORK_MUTEX') ? `network${optionalPort}` : `file:${path.join(cwd, 'yarn.lock')}`
+      console.log('mutex', mutex);
       const cacheDir = path.join(this.config.cacheDir, 'yarn')
       args = [
         ...args,
         '--non-interactive',
-        `--mutex=file:${path.join(cwd, 'yarn.lock')}`,
+        `--mutex=${mutex}`,
         `--preferred-cache-folder=${cacheDir}`,
         '--check-files',
       ]

--- a/src/yarn.ts
+++ b/src/yarn.ts
@@ -51,7 +51,6 @@ export default class Yarn {
       const port = this.config.scopedEnvVar('NETWORK_MUTEX_PORT')
       const optionalPort = port ? `:${port}` : ''
       const mutex = this.config.scopedEnvVar('USE_NETWORK_MUTEX') ? `network${optionalPort}` : `file:${path.join(cwd, 'yarn.lock')}`
-      console.log('mutex', mutex);
       const cacheDir = path.join(this.config.cacheDir, 'yarn')
       args = [
         ...args,


### PR DESCRIPTION
Allows us to use a network mutex for concurrent yarn instances. This is not any faster than `file:` but it does seem to reduce the mutex `ECOMPROMISED` errors. Could be beneficial in the future. 

[@W-14122700@](https://gus.my.salesforce.com/apex/ADM_WorkLocator?bugorworknumber=W-14122700)

QA: 
- Ran `SF_USE_NETWORK_MUTEX=true SFDX_NETWORK_MUTEX_PORT=31999 ../plugin-release-management/bin/run cli:install:jit:test`
- Inspected Network tab on activity monitor (notice custom port):
<img width="734" alt="Screenshot 2023-09-21 at 3 04 35 PM" src="https://github.com/oclif/plugin-plugins/assets/1715111/aef69113-c41f-48a0-9b56-075f499af1af">
