### PR TITLE
feat: allow --no-install on plugins link

### DIFF
--- a/src/commands/plugins/link.ts
+++ b/src/commands/plugins/link.ts
@@ -21,6 +21,11 @@ e.g. If you have a user-installed or core plugin that has a 'hello' command, ins
   static flags = {
     help: Flags.help({char: 'h'}),
     verbose: Flags.boolean({char: 'v'}),
+    install: Flags.boolean({
+      default: true,
+      allowNo: true,
+      description: 'Install dependencies after linking the plugin.',
+    }),
   }
 
   plugins = new Plugins(this.config)
@@ -29,7 +34,7 @@ e.g. If you have a user-installed or core plugin that has a 'hello' command, ins
     const {flags, args} = await this.parse(PluginsLink)
     this.plugins.verbose = flags.verbose
     ux.action.start(`Linking plugin ${chalk.cyan(args.path)}`)
-    await this.plugins.link(args.path)
+    await this.plugins.link(args.path, {install: flags.install})
     ux.action.stop()
   }
 }

--- a/src/plugins.ts
+++ b/src/plugins.ts
@@ -178,13 +178,13 @@ export default class Plugins {
     }))
   }
 
-  async link(p: string): Promise<void> {
+  async link(p: string, {install}: {install: boolean}): Promise<void> {
     const c = await Config.load(path.resolve(p))
     ux.action.start(`${this.config.name}: linking plugin ${c.name}`)
     this.isValidPlugin(c)
 
     // refresh will cause yarn.lock to install dependencies, including devDeps
-    await this.refresh({prod: false, all: false}, c.root)
+    if (install) await this.refresh({prod: false, all: false}, c.root)
     await this.add({type: 'link', name: c.name, root: c.root})
   }
 


### PR DESCRIPTION
Add `--[no-]install` flag to `plugins link`, which will bypass the `yarn install` step in the link process. This allows the command to run considerably faster in situations where you know you don't need to re-install dependencies, e.g. integration tests that run `plugins link` after having already run `yarn` on the plugin dir.