### PR TITLE
fix: HUSKY=0 on github installs

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "lint": "eslint . --ext .ts",
     "postpublish": "yarn run clean",
     "posttest": "yarn lint",
-    "prepare": "husky install && yarn build && yarn oclif manifest",
+    "prepare": "husky install && yarn build && oclif manifest",
     "prepublishOnly": "yarn run build && oclif lock && oclif manifest . && oclif readme",
     "pretest": "yarn build && tsc -p test --noEmit",
     "preversion": "yarn run clean",

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "lint": "eslint . --ext .ts",
     "postpublish": "yarn run clean",
     "posttest": "yarn lint",
-    "postinstall": "husky install",
+    "prepare": "husky install && yarn build",
     "prepublishOnly": "yarn run build && oclif lock && oclif manifest . && oclif readme",
     "pretest": "yarn build && tsc -p test --noEmit",
     "preversion": "yarn run clean",

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "lint": "eslint . --ext .ts",
     "postpublish": "yarn run clean",
     "posttest": "yarn lint",
-    "prepare": "husky install",
+    "postinstall": "husky install",
     "prepublishOnly": "yarn run build && oclif lock && oclif manifest . && oclif readme",
     "pretest": "yarn build && tsc -p test --noEmit",
     "preversion": "yarn run clean",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "author": "Salesforce",
   "bugs": "https://github.com/oclif/plugin-plugins/issues",
   "dependencies": {
-    "@oclif/core": "^3.7.1",
+    "@oclif/core": "^3.10.2",
     "chalk": "^5.3.0",
     "debug": "^4.3.4",
     "npm": "9.8.1",
@@ -81,7 +81,7 @@
     "lint": "eslint . --ext .ts",
     "postpublish": "yarn run clean",
     "posttest": "yarn lint",
-    "prepare": "husky install && yarn build && oclif manifest",
+    "prepare": "husky install && yarn build",
     "prepublishOnly": "yarn run build && oclif lock && oclif manifest . && oclif readme",
     "pretest": "yarn build && tsc -p test --noEmit",
     "preversion": "yarn run clean",

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "lint": "eslint . --ext .ts",
     "postpublish": "yarn run clean",
     "posttest": "yarn lint",
-    "prepare": "husky install && yarn build",
+    "prepare": "husky install && yarn build && yarn oclif manifest",
     "prepublishOnly": "yarn run build && oclif lock && oclif manifest . && oclif readme",
     "pretest": "yarn build && tsc -p test --noEmit",
     "preversion": "yarn run clean",

--- a/src/plugins.ts
+++ b/src/plugins.ts
@@ -85,7 +85,7 @@ export default class Plugins {
       if (name.includes(':')) {
         // url
         const url = name
-        await this.yarn.exec([...add, '--ignore-scripts', url], yarnOpts)
+        await this.yarn.exec([...add, url], yarnOpts)
         const {dependencies} = await this.pjson()
         name = Object.entries(dependencies ?? {}).find(([, u]) => u === url)![0]
         const root = join(this.config.dataDir, 'node_modules', name)
@@ -106,7 +106,6 @@ export default class Plugins {
             // CJS plugins can be auto-transpiled at runtime but ESM plugins
             // cannot. To support ESM plugins we need to compile them after
             // installing them.
-            await this.yarn.exec(['install'], {...yarnOpts, cwd: plugin.root})
             await this.yarn.exec(['run', 'tsc'], {...yarnOpts, cwd: plugin.root})
           } catch (error) {
             this.debug(error)
@@ -178,7 +177,6 @@ export default class Plugins {
       return unfriendly
     }
 
-    this.debug(`expanded package name ${unfriendly} not found, using given package name ${name}`)
     return name
   }
 

--- a/src/plugins.ts
+++ b/src/plugins.ts
@@ -88,29 +88,17 @@ export default class Plugins {
         await this.yarn.exec([...add, url], yarnOpts)
         const {dependencies} = await this.pjson()
         name = Object.entries(dependencies ?? {}).find(([, u]) => u === url)![0]
-        const root = join(this.config.dataDir, 'node_modules', name)
         plugin = await Config.load({
           devPlugins: false,
           name,
-          root,
+          root: join(this.config.dataDir, 'node_modules', name),
           userPlugins: false,
         })
-        await this.refresh({all: true, prod: true})
+        await this.refresh({all: true, prod: true}, plugin.root)
 
         this.isValidPlugin(plugin)
 
         await this.add({name, type: 'user', url})
-
-        if (plugin.getPluginsList().find((p) => p.root === root)?.moduleType === 'module') {
-          try {
-            // CJS plugins can be auto-transpiled at runtime but ESM plugins
-            // cannot. To support ESM plugins we need to compile them after
-            // installing them.
-            await this.yarn.exec(['run', 'tsc'], {...yarnOpts, cwd: plugin.root})
-          } catch (error) {
-            this.debug(error)
-          }
-        }
       } else {
         // npm
         const range = validRange(tag)
@@ -223,12 +211,10 @@ export default class Plugins {
 
     const pluginRoots = [...roots]
     if (options.all) {
-      const plugins = await this.list()
-      const userPluginsRoots = plugins
-        .filter((p) => p.type === 'user' && !p.url)
-        .map((p) => this.config.plugins.get(p.name)?.root)
-        // eslint-disable-next-line unicorn/prefer-native-coercion-functions
-        .filter((r): r is string => Boolean(r))
+      const userPluginsRoots = this.config
+        .getPluginsList()
+        .filter((p) => p.type === 'user')
+        .map((p) => p.root)
       pluginRoots.push(...userPluginsRoots)
     }
 

--- a/src/plugins.ts
+++ b/src/plugins.ts
@@ -180,6 +180,7 @@ export default class Plugins {
       return unfriendly
     }
 
+    this.debug(`expanded package name ${unfriendly} not found, using given package name ${name}`)
     return name
   }
 

--- a/src/yarn.ts
+++ b/src/yarn.ts
@@ -92,9 +92,18 @@ export default class Yarn {
     const cache = YarnMessagesCache.getInstance()
 
     return new Promise((resolve, reject) => {
-      // YARN_IGNORE_PATH=1 prevents yarn from resolving to the globally configured yarn binary.
-      // In other words, it ensures that it resolves to the yarn binary that is available in the node_modules directory.
-      const forked = fork(modulePath, args, {...options, env: {...process.env, YARN_IGNORE_PATH: '1'}})
+      const forked = fork(modulePath, args, {
+        ...options,
+        env: {
+          ...process.env,
+          // Disable husky hooks because a plugin might be trying to install them, which will
+          // break the install since the install location isn't a .git directory.
+          HUSKY: '0',
+          // YARN_IGNORE_PATH=1 prevents yarn from resolving to the globally configured yarn binary.
+          // In other words, it ensures that it resolves to the yarn binary that is available in the node_modules directory.
+          YARN_IGNORE_PATH: '1',
+        },
+      })
       forked.stderr?.on('data', (d: Buffer) => {
         if (!options.silent) {
           const str = d.toString()

--- a/yarn.lock
+++ b/yarn.lock
@@ -651,7 +651,7 @@
     wordwrap "^1.0.0"
     wrap-ansi "^7.0.0"
 
-"@oclif/core@^3.0.4", "@oclif/core@^3.2.1", "@oclif/core@^3.3.1", "@oclif/core@^3.7.1":
+"@oclif/core@^3.0.4", "@oclif/core@^3.2.1", "@oclif/core@^3.3.1":
   version "3.9.1"
   resolved "https://registry.yarnpkg.com/@oclif/core/-/core-3.9.1.tgz#056cf2e5b0962eac371a31d12963b188ca314716"
   integrity sha512-ZVz2TY8f0cA2HHIWdIAYOjpKynEyF481cKs1J6olDViLZ4OJonuLgGWUFs9luaadBcYtRoVuM3Ox1cdSqeUWFw==
@@ -678,6 +678,38 @@
     strip-ansi "^6.0.1"
     supports-color "^8.1.1"
     supports-hyperlinks "^2.2.0"
+    widest-line "^3.1.0"
+    wordwrap "^1.0.0"
+    wrap-ansi "^7.0.0"
+
+"@oclif/core@^3.10.2":
+  version "3.10.2"
+  resolved "https://registry.yarnpkg.com/@oclif/core/-/core-3.10.2.tgz#bed039f3b39208c6d4042ddd3e02fb237d78bf6d"
+  integrity sha512-tpOhDXPKLMavFsjrWpF1sTdyvOgcSlWBP+puO60XYnDk4+c1ghK7Pr7AA83VIyyUqUSBaxKjUJcZJJHGYfXuIA==
+  dependencies:
+    ansi-escapes "^4.3.2"
+    ansi-styles "^4.3.0"
+    cardinal "^2.1.1"
+    chalk "^4.1.2"
+    clean-stack "^3.0.1"
+    cli-progress "^3.12.0"
+    debug "^4.3.4"
+    ejs "^3.1.9"
+    get-package-type "^0.1.0"
+    globby "^11.1.0"
+    hyperlinker "^1.0.0"
+    indent-string "^4.0.0"
+    is-wsl "^2.2.0"
+    js-yaml "^3.14.1"
+    natural-orderby "^2.0.3"
+    object-treeify "^1.1.33"
+    password-prompt "^1.1.2"
+    slice-ansi "^4.0.0"
+    string-width "^4.2.3"
+    strip-ansi "^6.0.1"
+    supports-color "^8.1.1"
+    supports-hyperlinks "^2.2.0"
+    tsconfck "^3.0.0"
     widest-line "^3.1.0"
     wordwrap "^1.0.0"
     wrap-ansi "^7.0.0"
@@ -6640,6 +6672,11 @@ ts-node@^10.8.1, ts-node@^10.9.1:
     make-error "^1.1.1"
     v8-compile-cache-lib "^3.0.1"
     yn "3.1.1"
+
+tsconfck@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/tsconfck/-/tsconfck-3.0.0.tgz#b469f1ced12973bbec3209a55ed8de3bb04223c9"
+  integrity sha512-w3wnsIrJNi7avf4Zb0VjOoodoO0woEqGgZGQm+LHH9przdUI+XDKsWAXwxHA1DaRTjeuZNcregSzr7RaA8zG9A==
 
 tsconfig-paths@^3.14.2:
   version "3.14.2"


### PR DESCRIPTION
- Add `HUSKY=0` env var during yarn executions to avoid husky failures
- Only compile plugin after install if it's ESM && `tsconfig.json` exists. 

#### QA
use `nightly` sf since that will have the version of oclif/core that can auto-transpile CJS-github plugins 
- `sf plugins install oclif/version`, `sf version`
- `sf plugins install mdonnalley/plugin-dummy`, `sf hello world`