### PR TITLE
fix: allow installing legacy plugins if @oclif/plugin-legacy in plugins

### DIFF
--- a/src/plugins.ts
+++ b/src/plugins.ts
@@ -354,7 +354,7 @@ export default class Plugins {
     if (p.valid) return true
 
     if (
-      !this.config.plugins.get('@oclif/plugin-legacy') ||
+      this.config.plugins.get('@oclif/plugin-legacy') ||
       // @ts-expect-error because _base is private
       p._base.includes('@oclif/plugin-legacy')
     ) {

--- a/test/integration/install.integration.ts
+++ b/test/integration/install.integration.ts
@@ -236,4 +236,15 @@ describe('install/uninstall integration tests', () => {
       expect(result.some((r) => r.name === '@oclif/plugin-test-esm-1')).to.be.false
     })
   })
+
+  describe('legacy plugin', () => {
+    it('should install legacy plugin', async () => {
+      await PluginsInstall.run(['@oclif/plugin-legacy'], cwd)
+      await PluginsInstall.run(['@heroku-cli/plugin-ps-exec', '--silent'], cwd)
+
+      const result = await PluginsIndex.run([], cwd)
+      expect(stdoutStub.calledWith(match('@heroku-cli/plugin-ps-exec'))).to.be.true
+      expect(result.some((r) => r.name === '@heroku-cli/plugin-ps-exec')).to.be.true
+    })
+  })
 })


### PR DESCRIPTION
Fixes what appears to an oversight in https://github.com/oclif/plugin-plugins/pull/582.
Adds an integration test to avoid future issues.