### PR TITLE
fix: all error and warnings to stderr, this.log in commands

### DIFF
--- a/src/commands/plugins/install.ts
+++ b/src/commands/plugins/install.ts
@@ -165,7 +165,7 @@ e.g. If you have a core plugin that has a 'hello' command, installing a user-ins
 
       YarnMessagesCache.getInstance().flush(plugin)
 
-      ux.log(chalk.green(`\nSuccessfully installed ${plugin.name} v${plugin.version}`))
+      this.log(chalk.green(`\nSuccessfully installed ${plugin.name} v${plugin.version}`))
     }
   }
 }

--- a/src/util.ts
+++ b/src/util.ts
@@ -131,10 +131,10 @@ export class YarnMessagesCache {
     }
 
     if (plugin) {
-      ux.log(`\nThese warnings can only be addressed by the owner(s) of ${plugin.name}.`)
+      ux.logToStderr(`\nThese warnings can only be addressed by the owner(s) of ${plugin.name}.`)
 
       if (plugin.pjson.bugs || plugin.pjson.repository) {
-        ux.log(
+        ux.logToStderr(
           `We suggest that you create an issue at ${
             plugin.pjson.bugs ?? plugin.pjson.repository
           } and ask the plugin owners to address them.\n`,
@@ -143,7 +143,7 @@ export class YarnMessagesCache {
     }
 
     if (YarnMessagesCache.errors.size === 0) return
-    ux.log('\nThe following errors occurred:')
+    ux.logToStderr('\nThe following errors occurred:')
     for (const err of YarnMessagesCache.errors) {
       ux.error(err, {exit: false})
     }


### PR DESCRIPTION
- Send all errors and warning messages in `YarnWarningCache` to stderr
- Use `this.log` in `plugins install` to log success message so that it can automatically be hidden when `--json` is present

@W-14457843@