### PR TITLE
fix: handle spaces in node bin path

### DIFF
--- a/src/util.ts
+++ b/src/util.ts
@@ -73,7 +73,10 @@ export async function findNode(root: string): Promise<string> {
 
   // Check to see if node is installed
   const nodeShellString = shelljs.which('node')
-  if (nodeShellString?.code === 0 && nodeShellString?.stdout) return nodeShellString.stdout
+  if (nodeShellString?.code === 0 && nodeShellString?.stdout) {
+    // wrap node path in double quotes to deal with spaces
+    return `"${nodeShellString.stdout}"`
+  }
 
   const err = new Error('Cannot locate node executable.')
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment


### PR DESCRIPTION
Reported here:
https://github.com/forcedotcom/cli/issues/2564

plugin-plugins v4 will always perform a check to ensure a plugin exists in npm (`npm show <plugin> dist-tags`), since it uses the bundled npm instead of the global one it requires to call it using node (so it tries to get the path to node and path to npm-cli.js).

on plugin-plugins v3 this check would only happen if you tried to install a plugin and:
1) its name didn't include a `@`
2) root CLI didn't specify `pjson.oclif.scope

but `await this.npmHasPackage(unfriendly)` was always silently failing on windows (prob on mac/linux too) if the path to node contains spaces. 
https://github.com/oclif/plugin-plugins/blob/5ba86b5dd7d44a3cb317437055ea3db40318ced3/src/plugins.ts#L93

v4 made `npmHasPackage` thrown on not found:
https://github.com/oclif/plugin-plugins/blob/76ea07078eb8c00ea5d6730c4e32b9776dac1503/src/plugins.ts#L125-L126

This PR fixes the error caused on windows when the path to the node binary contains spaces.