### PR TITLE
fix: enable --json for plugins install

### DIFF
--- a/src/commands/plugins/install.ts
+++ b/src/commands/plugins/install.ts
@@ -21,6 +21,8 @@ Installation of a user-installed plugin will override a core plugin.
 e.g. If you have a core plugin that has a 'hello' command, installing a user-installed plugin with a 'hello' command will override the core plugin implementation. This is useful if a user needs to update core plugin functionality in the CLI without the need to patch and update the whole CLI.
 `
 
+  public static enableJsonFlag = true
+
   static examples = [
     '$ <%= config.bin %> plugins:install <%- config.pjson.oclif.examplePlugin || "myplugin" %> ',
     '$ <%= config.bin %> plugins:install https://github.com/someuser/someplugin',


### PR DESCRIPTION
enables `--json` flag for plugins:install

@W-14457843@
[sf package version create --json not returning proper json output#2562](https://github.com/forcedotcom/cli/issues/2562)