### PR TITLE
fix: handle spaces in node/npm path

### DIFF
--- a/src/plugins.ts
+++ b/src/plugins.ts
@@ -396,6 +396,7 @@ export default class Plugins {
     this.debug(`Using node executable located at: ${nodeExecutable}`)
     this.debug(`Using npm executable located at: ${npmCli}`)
 
+    // wrap node and path in double quotes to deal with spaces
     const command = `"${nodeExecutable}" "${npmCli}" show ${name} dist-tags`
 
     let npmShowResult

--- a/src/plugins.ts
+++ b/src/plugins.ts
@@ -396,7 +396,7 @@ export default class Plugins {
     this.debug(`Using node executable located at: ${nodeExecutable}`)
     this.debug(`Using npm executable located at: ${npmCli}`)
 
-    const command = `${nodeExecutable} ${npmCli} show ${name} dist-tags`
+    const command = `"${nodeExecutable}" "${npmCli}" show ${name} dist-tags`
 
     let npmShowResult
     try {

--- a/src/util.ts
+++ b/src/util.ts
@@ -74,8 +74,7 @@ export async function findNode(root: string): Promise<string> {
   // Check to see if node is installed
   const nodeShellString = shelljs.which('node')
   if (nodeShellString?.code === 0 && nodeShellString?.stdout) {
-    // wrap node path in double quotes to deal with spaces
-    return `"${nodeShellString.stdout}"`
+    return `${nodeShellString.stdout}`
   }
 
   const err = new Error('Cannot locate node executable.')


### PR DESCRIPTION
Fixes: https://github.com/forcedotcom/cli/issues/2564

Follow-up from: https://github.com/oclif/plugin-plugins/pull/711

The fix in 711 worked on my windows box because:
1) tested with latest sf installed from npm
2) the path to my node bin has a space

`plugin-plugins` get the path to the npm-cli.js from the bundled one, which in my case it didn't contain a space in the path so only quoting the node bin path was enough.

When using a windows installer, both the node binary and npm-cli.js file come from the same CLI dir so both need to be double-quoted when passed to shelljs.exec.

@ W-14480077@