### PR TITLE
fix: respect scoped NPM_REGISTRY env var when running npm show

### DIFF
--- a/src/plugins.ts
+++ b/src/plugins.ts
@@ -396,8 +396,10 @@ export default class Plugins {
     this.debug(`Using node executable located at: ${nodeExecutable}`)
     this.debug(`Using npm executable located at: ${npmCli}`)
 
+    const registry = this.config.scopedEnvVar('NPM_REGISTRY')
+    const registryFlag = registry ? `--registry=${registry}` : ''
     // wrap node and path in double quotes to deal with spaces
-    const command = `"${nodeExecutable}" "${npmCli}" show ${name} dist-tags`
+    const command = `"${nodeExecutable}" "${npmCli}" show ${name} dist-tags ${registryFlag}`
 
     let npmShowResult
     try {


### PR DESCRIPTION
Currently plugins that have never been publish to the npm registry (but have been published to a local or private registry) won't pass validation since `npm show` always runs against the npm public registry. This PR adds the `--registry` flag if the scoped `NPM_REGISTRY` env var exists.
