### PR TITLE
feat: reset --reinstall --hard

### DIFF
--- a/src/commands/plugins/reset.ts
+++ b/src/commands/plugins/reset.ts
@@ -61,12 +61,13 @@ export default class Reset extends Command {
     }
 
     if (flags.reinstall) {
+      this.log('Reinstall flag passed:')
       // These need to run sequentially so as to avoid write conflicts to the package.json
       for (const plugin of userPlugins) {
         if (plugin.type === 'link') {
           try {
             const newPlugin = await plugins.link(plugin.root, {install: false})
-            const newVersion = chalk.dim(`${newPlugin.version}`)
+            const newVersion = chalk.dim(`-> ${newPlugin.version}`)
             this.log(`✅ Relinked ${plugin.name} ${newVersion}`)
           } catch {
             this.warn(`Failed to relink ${plugin.name}`)

--- a/src/commands/plugins/reset.ts
+++ b/src/commands/plugins/reset.ts
@@ -1,20 +1,80 @@
-import {Command} from '@oclif/core'
+/* eslint-disable no-await-in-loop */
+import {Command, Flags} from '@oclif/core'
 import chalk from 'chalk'
+import {rm} from 'node:fs/promises'
+import {join} from 'node:path'
 
 import Plugins from '../../plugins.js'
 
 export default class Reset extends Command {
+  static flags = {
+    hard: Flags.boolean({
+      summary: 'Delete node_modules and package manager related files in addition to uninstalling plugins.',
+    }),
+    reinstall: Flags.boolean({
+      summary: 'Reinstall all plugins after uninstalling.',
+    }),
+  }
+
   static summary = 'Remove all user-installed and linked plugins.'
 
   async run(): Promise<void> {
+    const {flags} = await this.parse(Reset)
     const plugins = new Plugins(this.config)
     const userPlugins = await plugins.list()
 
-    this.log(`Uninstalling ${userPlugins.length} plugin${userPlugins.length === 0 ? '' : 's'}`)
+    this.log(`Found the following ${userPlugins.length} plugin${userPlugins.length === 0 ? '' : 's'}:`)
     for (const plugin of userPlugins) {
-      this.log(`• ${plugin.name} ${chalk.dim(`(${plugin.type})`)}`)
+      this.log(`- ${plugin.name} ${chalk.dim(`(${plugin.type})`)}`)
     }
 
-    await Promise.all(userPlugins.map(async (plugin) => plugins.uninstall(plugin.name)))
+    // These need to run sequentially so as to avoid write conflicts to the package.json
+    for (const plugin of userPlugins) {
+      try {
+        await plugins.uninstall(plugin.name)
+        this.log(`✅ Uninstalled ${plugin.name}`)
+      } catch {
+        this.warn(`Failed to uninstall ${plugin.name}`)
+      }
+    }
+
+    if (flags.hard) {
+      const filesToDelete = [
+        join(this.config.dataDir, 'node_modules'),
+        join(this.config.dataDir, 'package.json'),
+        join(this.config.dataDir, 'yarn.lock'),
+        join(this.config.dataDir, 'package-lock.json'),
+      ]
+
+      this.log('✅ Removed the following files:')
+      for (const file of filesToDelete) {
+        this.log(`- ${file}`)
+      }
+
+      await Promise.all(filesToDelete.map((file) => rm(file, {force: true, recursive: true})))
+    }
+
+    if (flags.reinstall) {
+      // These need to run sequentially so as to avoid write conflicts to the package.json
+      for (const plugin of userPlugins) {
+        if (plugin.type === 'link') {
+          try {
+            await plugins.link(plugin.root, {install: false})
+            this.log(`✅ Relinked ${plugin.name}`)
+          } catch {
+            this.warn(`Failed to relink ${plugin.name}`)
+          }
+        }
+
+        if (plugin.type === 'user') {
+          try {
+            await plugins.install(plugin.name, {tag: plugin.tag})
+            this.log(`✅ Reinstalled ${plugin.name}`)
+          } catch {
+            this.warn(`Failed to reinstall ${plugin.name}`)
+          }
+        }
+      }
+    }
   }
 }

--- a/src/commands/plugins/reset.ts
+++ b/src/commands/plugins/reset.ts
@@ -65,8 +65,9 @@ export default class Reset extends Command {
       for (const plugin of userPlugins) {
         if (plugin.type === 'link') {
           try {
-            await plugins.link(plugin.root, {install: false})
-            this.log(`✅ Relinked ${plugin.name}`)
+            const newPlugin = await plugins.link(plugin.root, {install: false})
+            const newVersion = chalk.dim(`${newPlugin.version}`)
+            this.log(`✅ Relinked ${plugin.name} ${newVersion}`)
           } catch {
             this.warn(`Failed to relink ${plugin.name}`)
           }

--- a/src/plugins.ts
+++ b/src/plugins.ts
@@ -158,7 +158,7 @@ export default class Plugins {
     }
   }
 
-  async link(p: string, {install}: {install: boolean}): Promise<void> {
+  async link(p: string, {install}: {install: boolean}): Promise<Interfaces.Config> {
     const c = await Config.load(resolve(p))
 
     this.isValidPlugin(c)
@@ -166,6 +166,8 @@ export default class Plugins {
     // refresh will cause yarn.lock to install dependencies, including devDeps
     if (install) await this.refresh({all: false, prod: false}, c.root)
     await this.add({name: c.name, root: c.root, type: 'link'})
+
+    return c
   }
 
   async list(): Promise<(Interfaces.PJSON.PluginTypes.Link | Interfaces.PJSON.PluginTypes.User)[]> {

--- a/src/plugins.ts
+++ b/src/plugins.ts
@@ -160,7 +160,7 @@ export default class Plugins {
 
   async link(p: string, {install}: {install: boolean}): Promise<void> {
     const c = await Config.load(resolve(p))
-    ux.action.start(`${this.config.name}: linking plugin ${c.name}`)
+
     this.isValidPlugin(c)
 
     // refresh will cause yarn.lock to install dependencies, including devDeps


### PR DESCRIPTION
Adds `--reinstall` and `--hard` flags to `plugins reset`

`--reinstall` allows users to automatically reinstall every plugin that gets uninstalled
`--hard` will force remove all package manager related files (node_modules, package.json, yarn.lock, package-lock.json) from data directory (`~/.local/share/<CLI>`)

The goal is to provide users an easy way to get themselves into a clean state if something should go wrong in the upcoming transition from `yarn` to `npm` (https://github.com/oclif/plugin-plugins/pull/776)

https://github.com/oclif/plugin-plugins/assets/10244328/9f57f514-a727-4c19-97cb-14a2bce877fa



