### PR TITLE
fix: display url when resetting plugin from url

### DIFF
--- a/src/commands/plugins/reset.ts
+++ b/src/commands/plugins/reset.ts
@@ -78,7 +78,8 @@ export default class Reset extends Command {
           try {
             const newPlugin = await plugins.install(plugin.name, {tag: plugin.tag})
             const newVersion = chalk.dim(`-> ${newPlugin.version}`)
-            this.log(`✅ Reinstalled ${plugin.name}@${plugin.tag} ${newVersion}`)
+            const tag = plugin.tag ? `@${plugin.tag}` : plugin.url ? ` (${plugin.url})` : ''
+            this.log(`✅ Reinstalled ${plugin.name}${tag} ${newVersion}`)
           } catch {
             this.warn(`Failed to reinstall ${plugin.name}`)
           }


### PR DESCRIPTION
Show url when reinstalling plugins during `plugins reset --reinstall`

![Screenshot 2024-01-31 at 1 16 16 PM](https://github.com/oclif/plugin-plugins/assets/10244328/e1ba7611-1fea-4505-bb2f-d170d71dfa1e)
