### PR TITLE
fix: use object-treeify instead of ux

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "npm": "10.5.0",
     "npm-package-arg": "^11.0.2",
     "npm-run-path": "^5.3.0",
+    "object-treeify": "^4.0.1",
     "semver": "^7.6.0",
     "validate-npm-package-name": "^5.0.0",
     "yarn": "^1.22.22"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5621,6 +5621,11 @@ object-treeify@^1.1.33:
   resolved "https://registry.npmjs.org/object-treeify/-/object-treeify-1.1.33.tgz"
   integrity sha512-EFVjAYfzWqWsBMRHPMAXLCDIJnpMhdWAqR7xG6M6a2cs6PMFpl/+Z20w9zDW4vkxOFfddegBKq9Rehd0bxWE7A==
 
+object-treeify@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/object-treeify/-/object-treeify-4.0.1.tgz#f91a7dec795d8275886e7f1bd78408f6975be825"
+  integrity sha512-Y6tg5rHfsefSkfKujv2SwHulInROy/rCL5F4w0QOWxut8AnxYxf0YmNhTh95Zfyxpsudo66uqkux0ACFnyMSgQ==
+
 object.assign@^4.1.5:
   version "4.1.5"
   resolved "https://registry.yarnpkg.com/object.assign/-/object.assign-4.1.5.tgz#3a833f9ab7fdb80fc9e8d2300c803d216d8fdbb0"


### PR DESCRIPTION
Use object-treeify directly instead of `ux.tree`. This should hopefully help some of the interoperability tests pass on https://github.com/oclif/core/pull/1056/
