### PR TITLE
fix: remove config from json response

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ EXAMPLES
   $ mycli plugins
 ```
 
-_See code: [src/commands/plugins/index.ts](https://github.com/oclif/plugin-plugins/blob/5.1.2/src/commands/plugins/index.ts)_
+_See code: [src/commands/plugins/index.ts](https://github.com/oclif/plugin-plugins/blob/5.1.3-qa.0/src/commands/plugins/index.ts)_
 
 ## `mycli plugins:inspect PLUGIN...`
 
@@ -144,7 +144,7 @@ EXAMPLES
   $ mycli plugins inspect myplugin
 ```
 
-_See code: [src/commands/plugins/inspect.ts](https://github.com/oclif/plugin-plugins/blob/5.1.2/src/commands/plugins/inspect.ts)_
+_See code: [src/commands/plugins/inspect.ts](https://github.com/oclif/plugin-plugins/blob/5.1.3-qa.0/src/commands/plugins/inspect.ts)_
 
 ## `mycli plugins install PLUGIN`
 
@@ -193,7 +193,7 @@ EXAMPLES
     $ mycli plugins install someuser/someplugin
 ```
 
-_See code: [src/commands/plugins/install.ts](https://github.com/oclif/plugin-plugins/blob/5.1.2/src/commands/plugins/install.ts)_
+_See code: [src/commands/plugins/install.ts](https://github.com/oclif/plugin-plugins/blob/5.1.3-qa.0/src/commands/plugins/install.ts)_
 
 ## `mycli plugins link PATH`
 
@@ -223,7 +223,7 @@ EXAMPLES
   $ mycli plugins link myplugin
 ```
 
-_See code: [src/commands/plugins/link.ts](https://github.com/oclif/plugin-plugins/blob/5.1.2/src/commands/plugins/link.ts)_
+_See code: [src/commands/plugins/link.ts](https://github.com/oclif/plugin-plugins/blob/5.1.3-qa.0/src/commands/plugins/link.ts)_
 
 ## `mycli plugins reset`
 
@@ -238,7 +238,7 @@ FLAGS
   --reinstall  Reinstall all plugins after uninstalling.
 ```
 
-_See code: [src/commands/plugins/reset.ts](https://github.com/oclif/plugin-plugins/blob/5.1.2/src/commands/plugins/reset.ts)_
+_See code: [src/commands/plugins/reset.ts](https://github.com/oclif/plugin-plugins/blob/5.1.3-qa.0/src/commands/plugins/reset.ts)_
 
 ## `mycli plugins uninstall [PLUGIN]`
 
@@ -266,7 +266,7 @@ EXAMPLES
   $ mycli plugins uninstall myplugin
 ```
 
-_See code: [src/commands/plugins/uninstall.ts](https://github.com/oclif/plugin-plugins/blob/5.1.2/src/commands/plugins/uninstall.ts)_
+_See code: [src/commands/plugins/uninstall.ts](https://github.com/oclif/plugin-plugins/blob/5.1.3-qa.0/src/commands/plugins/uninstall.ts)_
 
 ## `mycli plugins update`
 
@@ -284,7 +284,7 @@ DESCRIPTION
   Update installed plugins.
 ```
 
-_See code: [src/commands/plugins/update.ts](https://github.com/oclif/plugin-plugins/blob/5.1.2/src/commands/plugins/update.ts)_
+_See code: [src/commands/plugins/update.ts](https://github.com/oclif/plugin-plugins/blob/5.1.3-qa.0/src/commands/plugins/update.ts)_
 
 <!-- commandsstop -->
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@oclif/plugin-plugins",
   "description": "plugins plugin for oclif",
-  "version": "5.1.2",
+  "version": "5.1.3-qa.0",
   "author": "Salesforce",
   "bugs": "https://github.com/oclif/plugin-plugins/issues",
   "dependencies": {

--- a/src/commands/plugins/index.ts
+++ b/src/commands/plugins/index.ts
@@ -55,7 +55,17 @@ export default class PluginsIndex extends Command {
       this.displayJitPlugins(jitPlugins)
     }
 
-    return [...results.filter((p) => !p.parent), ...jitPlugins]
+    return [
+      ...results
+        .filter((p) => !p.parent)
+        .map((p) => {
+          // @ts-expect-error because we are removing the config property, which may or may not be there.
+          // eslint-disable-next-line @typescript-eslint/no-unused-vars
+          const {config, ...rest} = p
+          return rest
+        }),
+      ...jitPlugins,
+    ]
   }
 
   private createTree(plugin: Plugin) {


### PR DESCRIPTION
Remove the `config` property from json response on `plugins --json`

Fixes https://github.com/oclif/plugin-plugins/issues/876
@W-15839618@