### PR TITLE
feat: add `plugins:post`* hooks

### DIFF
--- a/src/commands/plugins/install.ts
+++ b/src/commands/plugins/install.ts
@@ -1,5 +1,5 @@
 /* eslint-disable no-await-in-loop */
-import {Args, Command, Errors, Flags, Interfaces, ux} from '@oclif/core'
+import {Args, Command, Errors, Flags, Interfaces, Plugin, ux} from '@oclif/core'
 import {bold, cyan} from 'ansis'
 import validate from 'validate-npm-package-name'
 
@@ -194,6 +194,12 @@ Use the <%= config.scopedEnvVarKey('NPM_REGISTRY') %> environment variable to se
         ux.action.stop(bold.red('failed'))
         throw error
       }
+
+      const pluginInstance = new Plugin(plugin)
+      await pluginInstance.load()
+      this.config.plugins.set(pluginInstance.name, pluginInstance)
+
+      await this.config.runHook('plugins:postinstall', {})
 
       ux.action.stop(`installed v${plugin.version}`)
     }

--- a/src/commands/plugins/uninstall.ts
+++ b/src/commands/plugins/uninstall.ts
@@ -48,6 +48,8 @@ export default class PluginsUninstall extends Command {
       logLevel: determineLogLevel(this.config, flags, 'silent'),
     })
 
+    let pluginNameToDelete: string | undefined
+
     if (argv.length === 0) argv.push('.')
     for (const plugin of argv as string[]) {
       const friendly = removeTags(plugins.friendlyName(plugin))
@@ -64,9 +66,10 @@ export default class PluginsUninstall extends Command {
 
       try {
         const {name} = unfriendly
-        const displayName = friendly === '.' ? name : friendly ?? name
+        const displayName = friendly === '.' ? name : (friendly ?? name)
         ux.action.start(`${this.config.name}: Uninstalling ${displayName}`)
         await plugins.uninstall(name)
+        pluginNameToDelete = name
       } catch (error) {
         ux.action.stop(bold.red('failed'))
         throw error
@@ -74,5 +77,11 @@ export default class PluginsUninstall extends Command {
 
       ux.action.stop()
     }
+
+    if (pluginNameToDelete) {
+      this.config.plugins.delete(pluginNameToDelete)
+    }
+
+    await this.config.runHook('plugins:postuninstall', {})
   }
 }

--- a/src/commands/plugins/uninstall.ts
+++ b/src/commands/plugins/uninstall.ts
@@ -48,7 +48,7 @@ export default class PluginsUninstall extends Command {
       logLevel: determineLogLevel(this.config, flags, 'silent'),
     })
 
-    let pluginNameToDelete: string | undefined
+    const pluginNameToDelete: string[] = []
 
     if (argv.length === 0) argv.push('.')
     for (const plugin of argv as string[]) {
@@ -69,7 +69,7 @@ export default class PluginsUninstall extends Command {
         const displayName = friendly === '.' ? name : (friendly ?? name)
         ux.action.start(`${this.config.name}: Uninstalling ${displayName}`)
         await plugins.uninstall(name)
-        pluginNameToDelete = name
+        pluginNameToDelete.push(name)
       } catch (error) {
         ux.action.stop(bold.red('failed'))
         throw error
@@ -78,8 +78,8 @@ export default class PluginsUninstall extends Command {
       ux.action.stop()
     }
 
-    if (pluginNameToDelete) {
-      this.config.plugins.delete(pluginNameToDelete)
+    for (const p of pluginNameToDelete) {
+      this.config.plugins.delete(p)
     }
 
     await this.config.runHook('plugins:postuninstall', {})


### PR DESCRIPTION
This PR adds 2 new hooks:

`plugins:postinstall`: runs after `plugins install`
`plugins:postuninstall`: runs after `plugins uninstall`

Added for the autocomplete refresh-cache hook:
https://github.com/oclif/plugin-autocomplete/pull/753

See QA steps on the linked PR ⬆️ 

@W-12465784@
