### PR TITLE
fix(W-18696886): resolve package name when using file url

### DIFF
--- a/src/plugins.ts
+++ b/src/plugins.ts
@@ -147,9 +147,18 @@ export default class Plugins {
         const {dependencies} = await this.pjson()
         const {default: npa} = await import('npm-package-arg')
         const normalizedUrl = npa(url)
+        console.log({
+          normalizedUrl,
+          url,
+        })
         const matches = Object.entries(dependencies ?? {}).find(([, u]) => {
           const normalized = npa(u)
 
+          console.log('------')
+          console.log({
+            normalized,
+            u,
+          })
           // for local file paths
           if (normalized.type === 'file' && normalized.fetchSpec) {
             return url.endsWith(normalized.fetchSpec)
@@ -162,6 +171,7 @@ export default class Plugins {
             normalized.hosted?.project === normalizedUrl.hosted?.project
           )
         })
+        console.log({matches})
         const installedPluginName = matches?.[0]
         if (!installedPluginName) throw new Errors.CLIError(`Could not find plugin name for ${url}`)
         const root = join(this.config.dataDir, 'node_modules', installedPluginName)

--- a/src/plugins.ts
+++ b/src/plugins.ts
@@ -149,6 +149,13 @@ export default class Plugins {
         const normalizedUrl = npa(url)
         const matches = Object.entries(dependencies ?? {}).find(([, u]) => {
           const normalized = npa(u)
+
+          // for local file paths
+          if (normalized.type === 'file' && normalizedUrl.fetchSpec) {
+            return url.endsWith(normalizedUrl.fetchSpec)
+          }
+
+          // for hosted git urls
           return (
             normalized.hosted?.type === normalizedUrl.hosted?.type &&
             normalized.hosted?.user === normalizedUrl.hosted?.user &&

--- a/src/plugins.ts
+++ b/src/plugins.ts
@@ -151,8 +151,8 @@ export default class Plugins {
           const normalized = npa(u)
 
           // for local file paths
-          if (normalized.type === 'file' && normalizedUrl.fetchSpec) {
-            return url.endsWith(normalizedUrl.fetchSpec)
+          if (normalized.type === 'file' && normalized.fetchSpec) {
+            return url.endsWith(normalized.fetchSpec)
           }
 
           // for hosted git urls

--- a/src/plugins.ts
+++ b/src/plugins.ts
@@ -191,7 +191,7 @@ export default class Plugins {
         this.debug(results)
         if (!Object.values(results).every(Boolean)) {
           ux.warn(
-            `This plugin from github may not work as expected because the prepare script did not produce all the expected files.`,
+            `This plugin may not work as expected because the prepare script did not produce all the expected files.`,
           )
         }
       } else {


### PR DESCRIPTION
When installing multiple plugins from a file url, plugins could get overwritten because the logic used to determine the package name always assumed that it was handling a git url

@W-18696886@