### PR TITLE
fix(W-20013915): add warning about deprecating auto-install feature

### DIFF
--- a/src/plugins.ts
+++ b/src/plugins.ts
@@ -249,6 +249,9 @@ export default class Plugins {
       if (await fileExists(join(c.root, 'yarn.lock'))) {
         this.debug('installing dependencies with yarn')
         const yarn = new Yarn({config: this.config, logLevel: this.logLevel})
+        ux.warn(
+          `The ${ux.colorize('dim', 'plugins link')} command will no longer auto install dependencies in future versions. Please run ${ux.colorize('dim', 'yarn')} manually in the plugin directory before linking.`,
+        )
         await yarn.install([], {
           cwd: c.root,
           logLevel: this.logLevel,


### PR DESCRIPTION
Warn that auto-install feature of `plugins link` will be removed in the next major version. See #1179 for more context

@W-20013915@