### PR TITLE
fix: repository prefix devcenter links

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
   ],
   "license": "MIT",
   "oclif": {
+    "repositoryPrefix": "<%- repo %>/blob/<%- version %>/<%- commandPath %>",
     "commands": "./lib/commands",
     "hooks": {
       "update": "./lib/hooks/update.js"


### PR DESCRIPTION
## Description
adding repositoryPrefix so CLI command doc links point to this plugin’s repo and fix broken DevCenter links

## Related
[W-19690160](https://gus.lightning.force.com/a07EE00002M3HdRYAV)