### PR TITLE
fix: use process.execPath for .js module spawning on all platforms @W-21984392@

### DIFF
--- a/src/spawn.ts
+++ b/src/spawn.ts
@@ -19,10 +19,10 @@ const debug = makeDebug('@oclif/plugin-plugins:spawn')
 
 export async function spawn(modulePath: string, args: string[] = [], {cwd, logLevel}: ExecOptions): Promise<Output> {
   return new Promise((resolve, reject) => {
-    // On windows, the global path to npm could be .cmd, .exe, or .js. If it's a .js file, we need to run it with node.
-    if (process.platform === 'win32' && modulePath.endsWith('.js')) {
-      args.unshift(`"${modulePath}"`)
-      modulePath = 'node'
+    if (modulePath.endsWith('.js')) {
+      const quote = process.platform === 'win32' ? `"${modulePath}"` : modulePath
+      args.unshift(quote)
+      modulePath = process.execPath
     }
 
     debug('modulePath', modulePath)

--- a/test/spawn.test.ts
+++ b/test/spawn.test.ts
@@ -1,5 +1,5 @@
 import {expect} from 'chai'
-import {chmodSync, mkdtempSync, rmSync, writeFileSync} from 'node:fs'
+import {chmodSync, mkdirSync, mkdtempSync, rmSync, writeFileSync} from 'node:fs'
 import {tmpdir} from 'node:os'
 import {join} from 'node:path'
 
@@ -34,6 +34,18 @@ describe('spawn', () => {
     const result = await spawn(script, ['--flag', 'value'], {cwd: tempDir, logLevel: 'silent'})
 
     expect(result.stdout).to.include('["--flag","value"]')
+  })
+
+  it('should handle .js module paths with spaces in the path', async () => {
+    const dir = join(tempDir, 'dir with spaces')
+    mkdirSync(dir)
+    const script = join(dir, 'my script.js')
+    writeFileSync(script, 'console.log("spaces-ok")\n')
+    chmodSync(script, '755')
+
+    const result = await spawn(script, [], {cwd: tempDir, logLevel: 'silent'})
+
+    expect(result.stdout).to.include('spaces-ok')
   })
 
   it('should not modify non-.js module paths', async () => {

--- a/test/spawn.test.ts
+++ b/test/spawn.test.ts
@@ -1,0 +1,48 @@
+import {expect} from 'chai'
+import {chmodSync, mkdtempSync, rmSync, writeFileSync} from 'node:fs'
+import {tmpdir} from 'node:os'
+import {join} from 'node:path'
+
+import {spawn} from '../src/spawn.js'
+
+describe('spawn', () => {
+  let tempDir: string
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), 'spawn-test-'))
+  })
+
+  afterEach(() => {
+    rmSync(tempDir, {force: true, recursive: true})
+  })
+
+  it('should invoke .js module paths via process.execPath', async () => {
+    const script = join(tempDir, 'test-script.js')
+    writeFileSync(script, '#!/usr/bin/env nonexistent-node-binary\nconsole.log("spawned-ok")\n')
+    chmodSync(script, '755')
+
+    const result = await spawn(script, [], {cwd: tempDir, logLevel: 'silent'})
+
+    expect(result.stdout).to.include('spawned-ok')
+  })
+
+  it('should pass args after the .js module path', async () => {
+    const script = join(tempDir, 'echo-args.js')
+    writeFileSync(script, 'console.log(JSON.stringify(process.argv.slice(2)))\n')
+    chmodSync(script, '755')
+
+    const result = await spawn(script, ['--flag', 'value'], {cwd: tempDir, logLevel: 'silent'})
+
+    expect(result.stdout).to.include('["--flag","value"]')
+  })
+
+  it('should not modify non-.js module paths', async () => {
+    const script = join(tempDir, 'test-bin')
+    writeFileSync(script, `#!/usr/bin/env bash\necho "bin-ok"\n`)
+    chmodSync(script, '755')
+
+    const result = await spawn(script, [], {cwd: tempDir, logLevel: 'silent'})
+
+    expect(result.stdout).to.include('bin-ok')
+  })
+})


### PR DESCRIPTION
## Summary
- Remove the `win32` platform guard in `spawn.ts` so `.js` module paths are invoked via Node on all platforms, not just Windows
- Use `process.execPath` instead of the string `'node'` — ensures the bundled Node binary is used in standalone tarball deployments
- Add unit tests covering `.js` path handling (Unix + args passthrough + paths with spaces) and non-`.js` path passthrough

Fixes https://github.com/oclif/plugin-plugins/issues/1293

## Work Item
@W-21984392@: [oclif][ISSUE] `spawn` fails with ENOENT on standalone tarballs (UNIX)

## Bug Reproduction

The bug occurs when a `.js` file (e.g., `npm-cli.js`) has a shebang pointing to a Node interpreter that doesn't exist on the host (common in standalone tarball deployments where only the bundled node exists):

```
=== OLD behavior: spawn .js directly ===
Spawning: /tmp/repro/npm-cli.js

ERROR: ENOENT — spawn /tmp/repro/npm-cli.js ENOENT
^ The OS tries the shebang interpreter (#!/usr/bin/nonexistent-node)
  which does not exist → ENOENT

=== NEW behavior: spawn via process.execPath ===
Spawning: /path/to/node /tmp/repro/npm-cli.js

Exit code: 0
Output: npm install success

✓ Fix works — process.execPath bypasses the broken shebang
```

On Unix, `ENOENT` from `spawn()` can mean "missing shebang interpreter," not just "target file missing" — which makes this error confusing to diagnose.

## Proof of Work
- Tests: 32 passing (0 failing)
- Lint: clean
- Type check: clean
- Build: clean

## Test plan
- [x] Reproduce ENOENT with bogus shebang `.js` file spawned directly
- [x] Verify fix: same `.js` file spawned via `process.execPath` succeeds
- [x] Unit test: `.js` paths invoked via `process.execPath` on Unix
- [x] Unit test: `.js` paths with spaces in the path
- [x] Unit test: args passed correctly after the module path
- [x] Unit test: non-`.js` paths remain unchanged
- [ ] Integration: `plugins:install` on standalone tarball (Linux, no system Node.js)
- [ ] Integration: `plugins:install` on Windows (paths with spaces)
- [ ] Integration: `plugins:install` with npm-installed CLI (system node)