### PR TITLE
fix: pass cwd to npmRunPathEnv to prevent PATH hijack @W-23797722@

### DIFF
--- a/src/spawn.ts
+++ b/src/spawn.ts
@@ -30,7 +30,7 @@ export async function spawn(modulePath: string, args: string[] = [], {cwd, logLe
     const spawned = cpSpawn(modulePath, args, {
       cwd,
       env: {
-        ...npmRunPathEnv(),
+        ...npmRunPathEnv({cwd}),
         // Disable husky hooks because a plugin might be trying to install them, which will
         // break the install since the install location isn't a .git directory.
         HUSKY: '0',


### PR DESCRIPTION
## Summary
- Pass `cwd` to `npmRunPathEnv()` in `src/spawn.ts` so the child process PATH is built relative to the plugin install directory, not `process.cwd()`
- Prevents an attacker-controlled `node_modules/.bin/node` in the repository from being resolved before the trusted Node runtime during JIT plugin installation

## Work Item
@W-23797722@: [Bug Bounty / H1] SF CLI - Automatic JIT plugin installation executes repository-local `node` before the trusted runtime

## Test plan
- [ ] Clone a repo with a malicious `node_modules/.bin/node` executable
- [ ] Run a JIT command (e.g. `sf dev audit messages`) and verify the malicious node is NOT executed
- [ ] Verify normal JIT plugin installation still works correctly